### PR TITLE
Add nodejs version to pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ For popular chains, one can use an already in-sync publicly available Indexer en
 
 ## Hydra CLI quickstart
 
+Prerquisties
+
+```text
+- NodeJs v12+
+```
+
 Run
 
 ```text

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For popular chains, one can use an already in-sync publicly available Indexer en
 Prerquisties
 
 ```text
-- NodeJs v12+
+- NodeJs v14+
 ```
 
 Run

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For popular chains, one can use an already in-sync publicly available Indexer en
 
 ## Hydra CLI quickstart
 
-Prerquisties
+Prerequisites
 
 ```text
 - NodeJs v14+

--- a/examples/v3/kusama-query-node/README.md
+++ b/examples/v3/kusama-query-node/README.md
@@ -6,6 +6,12 @@ It showcase the two main features of Hydra v3:
 - Dealing with runtime upgrades via spec filters
 - Using ad-hoc data loaders via block hooks
 
+## Prerquisties
+
+```text
+- NodeJs v14+
+```
+
 ## 1. Bootstrap
 
 Run

--- a/examples/v3/kusama-query-node/README.md
+++ b/examples/v3/kusama-query-node/README.md
@@ -6,9 +6,9 @@ It showcase the two main features of Hydra v3:
 - Dealing with runtime upgrades via spec filters
 - Using ad-hoc data loaders via block hooks
 
-## Prerquisties
+## Prerequisites
 
-```text
+```
 - NodeJs v14+
 ```
 

--- a/hydra-cli.md
+++ b/hydra-cli.md
@@ -2,6 +2,12 @@
 
 A cli tool for running a [Hydra](https://joystream.org/hydra) query node
 
+## Prerquisties
+
+```text
+- NodeJs v14+
+```
+
 ## Install
 
 Using `npx`:

--- a/hydra-cli.md
+++ b/hydra-cli.md
@@ -2,7 +2,7 @@
 
 A cli tool for running a [Hydra](https://joystream.org/hydra) query node
 
-## Prerquisties
+## Prerequisites
 
 ```text
 - NodeJs v14+


### PR DESCRIPTION
# Problem Description
The npx command to generate the sample projects seems to work properly only in node version 14 and above. Adding it in documentation to avoid confusion