### PR TITLE
Feature: Multi-chain processor

### DIFF
--- a/packages/hydra-common/package.json
+++ b/packages/hydra-common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cpurta/hydra-common",
+  "name": "@subsquid/hydra-common",
   "version": "4.2.0-alpha.6",
   "description": "Common Hydra tools",
   "main": "lib/index.js",

--- a/packages/hydra-common/package.json
+++ b/packages/hydra-common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@subsquid/hydra-common",
+  "name": "@cpurta/hydra-common",
   "version": "4.2.0-alpha.6",
   "description": "Common Hydra tools",
   "main": "lib/index.js",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.10",
+  "version": "4.2.0-alpha.12",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.17",
+  "version": "4.2.0-alpha.18",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.20",
+  "version": "4.2.0-alpha.22",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.24",
+  "version": "4.2.0-alpha.25",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.25",
+  "version": "4.2.0-alpha.26",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.23",
+  "version": "4.2.0-alpha.24",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.22",
+  "version": "4.2.0-alpha.23",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.9",
+  "version": "4.2.0-alpha.10",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.6",
+  "version": "4.2.0-alpha.7",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.11",
+  "version": "4.2.0-alpha.10",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.10",
+  "version": "4.2.0-alpha.11",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.8",
+  "version": "4.2.0-alpha.9",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.12",
+  "version": "4.2.0-alpha.13",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.16",
+  "version": "4.2.0-alpha.17",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@subsquid/hydra-processor",
+  "name": "@cpurta/hydra-processor",
   "version": "4.2.0-alpha.6",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
@@ -18,7 +18,7 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "hydra-processor",
-    "scope": "@subsquid",
+    "scope": "@cpurta",
     "plugins": [
       "@oclif/plugin-help",
       "@oclif/errors"

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.19",
+  "version": "4.2.0-alpha.20",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.18",
+  "version": "4.2.0-alpha.19",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.15",
+  "version": "4.2.0-alpha.16",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.13",
+  "version": "4.2.0-alpha.14",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.7",
+  "version": "4.2.0-alpha.8",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.26",
+  "version": "4.2.0-alpha.27",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cpurta/hydra-processor",
-  "version": "4.2.0-alpha.14",
+  "version": "4.2.0-alpha.15",
   "description": "Hydra Processor CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/hydra-processor/src/commands/run.ts
+++ b/packages/hydra-processor/src/commands/run.ts
@@ -10,9 +10,6 @@ export default class Run extends Command {
       char: 'm',
       description: 'Manifest file',
     }),
-    indexer: flags.string({
-      description: 'Indexer URL to source events',
-    }),
     env: flags.string({
       char: 'e',
       description: 'Path to a file with environment variables',
@@ -29,10 +26,6 @@ export default class Run extends Command {
     const { flags } = this.parse(Run)
 
     dotenv.config({ path: flags.env })
-
-    if (flags.indexer) {
-      process.env.INDEXER_ENDPOINT_URL = flags.indexer
-    }
 
     if (flags.manifest) {
       process.env.MANIFEST_PATH = flags.manifest

--- a/packages/hydra-processor/src/db/dal.ts
+++ b/packages/hydra-processor/src/db/dal.ts
@@ -16,13 +16,16 @@ export async function createDBConnection(): Promise<Connection> {
  * Get last event processed by the given mappings processor
  *
  * @param processorID Name of the processor
+ * @param substrateChain Name of the substrate chain
  */
 export async function loadState(
-  processorID: string
+  processorID: string,
+  substrateChain: string
 ): Promise<ProcessedEventsLogEntity | undefined> {
   return await getRepository(ProcessedEventsLogEntity).findOne({
     where: {
       processor: processorID,
+      substrateChain: substrateChain,
     },
     order: {
       eventId: 'DESC',
@@ -37,13 +40,14 @@ export async function loadState(
  * @param processorID Name of the processor
  */
 export async function countProcessedEvents(
-  processorID: string
+  processorID: string,
+  substrateChain: string
 ): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { cnt } = await getRepository(ProcessedEventsLogEntity)
     .createQueryBuilder('events')
     .select('COUNT(DISTINCT(events.event_id))', 'cnt')
-    .where({ processor: processorID })
+    .where({ processor: processorID, substrateChain: substrateChain })
     .getRawOne()!
 
   debug(`Total events count ${String(cnt)}`)

--- a/packages/hydra-processor/src/db/dal.ts
+++ b/packages/hydra-processor/src/db/dal.ts
@@ -40,14 +40,13 @@ export async function loadState(
  * @param processorID Name of the processor
  */
 export async function countProcessedEvents(
-  processorID: string,
-  substrateChain: string
+  processorID: string
 ): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { cnt } = await getRepository(ProcessedEventsLogEntity)
     .createQueryBuilder('events')
     .select('COUNT(DISTINCT(events.event_id))', 'cnt')
-    .where({ processor: processorID, substrateChain: substrateChain })
+    .where({ processor: processorID })
     .getRawOne()!
 
   debug(`Total events count ${String(cnt)}`)

--- a/packages/hydra-processor/src/entities/ProcessedEventsLogEntity.ts
+++ b/packages/hydra-processor/src/entities/ProcessedEventsLogEntity.ts
@@ -11,6 +11,10 @@ export class ProcessedEventsLogEntity {
   @Column()
   processor!: string
 
+  // Substrate chain name, e.g. 'kusama', 'polkadot', etc.
+  @Column()
+  substrateChain!: string
+
   // the indexed event reference
   @Column()
   @Index()

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -15,9 +15,9 @@ const debug = Debug('hydra-processor:mappings-executor')
 export class TransactionalExecutor implements IMappingExecutor {
   private mappingsLookup!: IMappingsLookup
 
-  async init(): Promise<void> {
-    info('Initializing mappings executor')
-    this.mappingsLookup = await getMappingsLookup()
+  async init(substrateChain: string): Promise<void> {
+    info(`Initializing ${substrateChain} mappings executor:`)
+    this.mappingsLookup = await getMappingsLookup(substrateChain)
   }
 
   async executeBlock(
@@ -59,8 +59,6 @@ export class TransactionalExecutor implements IMappingExecutor {
           store,
           extrinsic: event.extrinsic,
         }
-
-        debug(`Event context: ${JSON.stringify(ctx)}`)
 
         await this.mappingsLookup.call(mapping, ctx)
         i++

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -13,10 +13,12 @@ import { TxAwareBlockContext } from './tx-aware'
 const debug = Debug('hydra-processor:mappings-executor')
 
 export class TransactionalExecutor implements IMappingExecutor {
+  private substrateChain!: string
   private mappingsLookup!: IMappingsLookup
 
   async init(substrateChain: string): Promise<void> {
     info(`Initializing ${substrateChain} mappings executor:`)
+    this.substrateChain = substrateChain
     this.mappingsLookup = await getMappingsLookup(substrateChain)
   }
 
@@ -49,7 +51,7 @@ export class TransactionalExecutor implements IMappingExecutor {
       let i = 0
       for (const mapping of mappings) {
         const { event } = blockData.events[i]
-        debug(`Processing event ${event.id}`)
+        debug(`Processing event (${this.substrateChain}) ${event.id}`)
 
         if (conf().VERBOSE) debug(`JSON: ${JSON.stringify(event, null, 2)}`)
 
@@ -63,7 +65,7 @@ export class TransactionalExecutor implements IMappingExecutor {
         await this.mappingsLookup.call(mapping, ctx)
         i++
 
-        debug(`Event ${event.id} done`)
+        debug(`Event (${this.substrateChain}) ${event.id} done`)
       }
 
       for (const hook of post) {

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -60,6 +60,8 @@ export class TransactionalExecutor implements IMappingExecutor {
           extrinsic: event.extrinsic,
         }
 
+        debug(`Event context: ${JSON.stringify(ctx)}`)
+
         await this.mappingsLookup.call(mapping, ctx)
         i++
 

--- a/packages/hydra-processor/src/executor/index.ts
+++ b/packages/hydra-processor/src/executor/index.ts
@@ -1,28 +1,28 @@
 import { MappingsLookupService } from './MappingsLookupService'
-import { getManifest } from '../start/config'
+import { getManifestMapping } from '../start/config'
 import { IMappingExecutor } from './IMappingExecutor'
 import { IMappingsLookup } from './IMappingsLookup'
 import { TransactionalExecutor } from './TransactionalExecutor'
-
-let mappingExecutor: TransactionalExecutor
-let mappingsLookup: MappingsLookupService
 
 export * from './IMappingExecutor'
 export * from './IMappingsLookup'
 export * from './tx-aware'
 
-export async function getMappingExecutor(): Promise<IMappingExecutor> {
-  if (!mappingExecutor) {
-    mappingExecutor = new TransactionalExecutor()
-    await mappingExecutor.init()
-  }
+export async function getMappingExecutor(substrateChain: string): Promise<IMappingExecutor> {
+  
+  const mappingExecutor = new TransactionalExecutor()
+  await mappingExecutor.init(substrateChain)
+  
   return mappingExecutor
 }
 
-export async function getMappingsLookup(): Promise<IMappingsLookup> {
-  if (!mappingsLookup) {
-    mappingsLookup = new MappingsLookupService(getManifest().mappings)
-    await mappingsLookup.load()
+export async function getMappingsLookup(substrateChain: string): Promise<IMappingsLookup> {
+  const mapping = getManifestMapping(substrateChain)
+  if (!mapping) {
+    throw new Error(`No mapping found for chain ${substrateChain}`)
   }
+  const mappingsLookup = new MappingsLookupService(mapping)
+  await mappingsLookup.load()
+  
   return mappingsLookup
 }

--- a/packages/hydra-processor/src/executor/index.ts
+++ b/packages/hydra-processor/src/executor/index.ts
@@ -8,21 +8,39 @@ export * from './IMappingExecutor'
 export * from './IMappingsLookup'
 export * from './tx-aware'
 
+let mappingExecutors: Map<string, IMappingExecutor> = new Map()
+let mappingsLookups: Map<string, IMappingsLookup> = new Map()
+
 export async function getMappingExecutor(substrateChain: string): Promise<IMappingExecutor> {
+  if (!mappingExecutors.has(substrateChain)) {
+    const mappingExecutor = new TransactionalExecutor()
+    await mappingExecutor.init(substrateChain)
+    mappingExecutors.set(substrateChain, mappingExecutor)
+  }
   
-  const mappingExecutor = new TransactionalExecutor()
-  await mappingExecutor.init(substrateChain)
+  const mappingExecutor = mappingExecutors.get(substrateChain)
+  if (!mappingExecutor) {
+    throw new Error(`MappingExecutor not found for chain ${substrateChain}`)
+  }
   
   return mappingExecutor
 }
 
 export async function getMappingsLookup(substrateChain: string): Promise<IMappingsLookup> {
-  const mapping = getManifestMapping(substrateChain)
-  if (!mapping) {
-    throw new Error(`No mapping found for chain ${substrateChain}`)
+  if (!mappingsLookups.has(substrateChain)) {
+    const mapping = getManifestMapping(substrateChain)
+    if (!mapping) {
+      throw new Error(`No mapping found for chain ${substrateChain}`)
+    }
+    const mappingsLookup = new MappingsLookupService(mapping)
+    await mappingsLookup.load()
+    mappingsLookups.set(substrateChain, mappingsLookup)
   }
-  const mappingsLookup = new MappingsLookupService(mapping)
-  await mappingsLookup.load()
+
+  const mappingsLookup = mappingsLookups.get(substrateChain)
+  if (!mappingsLookup) {
+    throw new Error(`MappingsLookup not found for chain ${substrateChain}`)
+  }
   
   return mappingsLookup
 }

--- a/packages/hydra-processor/src/ingest/GraphQLSource.ts
+++ b/packages/hydra-processor/src/ingest/GraphQLSource.ts
@@ -43,14 +43,16 @@ query {
 `
 
 export class GraphQLSource implements IProcessorSource {
+  private substrateChain: string
   private indexerEndpointURL: string
   private graphClient: GraphQLClient
   private blockCache: FIFOCache<number, SubstrateBlock>
 
-  constructor(indexerEndpointURL: string) {
+  constructor(substrateChain: string ,indexerEndpointURL: string) {
+    this.substrateChain = substrateChain
     const _endpoint = indexerEndpointURL
     this.indexerEndpointURL = _endpoint
-    info(`Using Indexer API endpoint ${_endpoint}`)
+    info(`Using Indexer API endpoint (${this.substrateChain}): ${_endpoint}`)
     this.graphClient = new GraphQLClient(_endpoint)
     this.blockCache = new FIFOCache<number, SubstrateBlock>(
       conf().BLOCK_CACHE_CAPACITY

--- a/packages/hydra-processor/src/ingest/GraphQLSource.ts
+++ b/packages/hydra-processor/src/ingest/GraphQLSource.ts
@@ -7,7 +7,7 @@ import {
 import Debug from 'debug'
 import { GraphQLClient } from 'graphql-request'
 import { compact } from 'lodash'
-import { getConfig as conf } from '../start/config'
+import { getConfig as conf, getManifest } from '../start/config'
 import { IndexerStatus } from '../state'
 import { quotedJoin } from '../util/utils'
 import { IProcessorSource } from './'
@@ -42,11 +42,13 @@ query {
 `
 
 export class GraphQLSource implements IProcessorSource {
+  private indexerEndpointURL: string
   private graphClient: GraphQLClient
   private blockCache: FIFOCache<number, SubstrateBlock>
 
-  constructor() {
-    const _endpoint = conf().INDEXER_ENDPOINT_URL
+  constructor(indexerEndpointURL: string) {
+    const _endpoint = indexerEndpointURL
+    this.indexerEndpointURL = _endpoint
     debug(`Using Indexer API endpoint ${_endpoint}`)
     this.graphClient = new GraphQLClient(_endpoint)
     this.blockCache = new FIFOCache<number, SubstrateBlock>(
@@ -183,7 +185,7 @@ export class GraphQLSource implements IProcessorSource {
       onFailedAttempt: (i) =>
         debug(
           `Failed to connect to the indexer endpoint "${
-            conf().INDEXER_ENDPOINT_URL
+            this.indexerEndpointURL
           }" after ${i.attemptNumber} attempts. Retries left: ${i.retriesLeft}`
         ),
     })

--- a/packages/hydra-processor/src/ingest/GraphQLSource.ts
+++ b/packages/hydra-processor/src/ingest/GraphQLSource.ts
@@ -11,6 +11,7 @@ import { getConfig as conf, getManifest } from '../start/config'
 import { IndexerStatus } from '../state'
 import { quotedJoin } from '../util/utils'
 import { IProcessorSource } from './'
+import { info } from '../util/log'
 import { IndexerQuery } from './IProcessorSource'
 import pRetry from 'p-retry'
 
@@ -49,7 +50,7 @@ export class GraphQLSource implements IProcessorSource {
   constructor(indexerEndpointURL: string) {
     const _endpoint = indexerEndpointURL
     this.indexerEndpointURL = _endpoint
-    debug(`Using Indexer API endpoint ${_endpoint}`)
+    info(`Using Indexer API endpoint ${_endpoint}`)
     this.graphClient = new GraphQLClient(_endpoint)
     this.blockCache = new FIFOCache<number, SubstrateBlock>(
       conf().BLOCK_CACHE_CAPACITY

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -16,7 +16,7 @@ export async function getProcessorSource(substrateChain: string, indexerEndpoint
 
   const eventSource = eventSources.get(substrateChain)
   if (!eventSource) {
-    throw new Error(`No event source found for chain ${substrateChain}`)
+    throw new Error(`ProcessorSource not found for chain ${substrateChain}`)
   }
   
   return eventSource

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -2,15 +2,12 @@ import { GraphQLSource } from './GraphQLSource'
 import { IProcessorSource } from './IProcessorSource'
 import pImmediate from 'p-immediate'
 
-let eventSource: GraphQLSource
-
 export * from './IProcessorSource'
 
 export async function getProcessorSource(indexerEndpointURL: string): Promise<IProcessorSource> {
-  if (!eventSource) {
-    // just to make it async, do some async init here if needed
-    await pImmediate()
-    eventSource = new GraphQLSource(indexerEndpointURL)
-  }
+  // just to make it async, do some async init here if needed
+  await pImmediate()
+  const eventSource = new GraphQLSource(indexerEndpointURL)
+  
   return eventSource
 }

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -2,12 +2,22 @@ import { GraphQLSource } from './GraphQLSource'
 import { IProcessorSource } from './IProcessorSource'
 import pImmediate from 'p-immediate'
 
+let eventSources: Map<string, IProcessorSource> = new Map()
+
 export * from './IProcessorSource'
 
 export async function getProcessorSource(substrateChain: string, indexerEndpointURL: string): Promise<IProcessorSource> {
+  if (!eventSources.has(substrateChain)) {
   // just to make it async, do some async init here if needed
-  await pImmediate()
-  const eventSource = new GraphQLSource(substrateChain, indexerEndpointURL)
+    await pImmediate()
+    const eventSource = new GraphQLSource(substrateChain, indexerEndpointURL)
+    eventSources.set(substrateChain, eventSource)
+  }
+
+  const eventSource = eventSources.get(substrateChain)
+  if (!eventSource) {
+    throw new Error(`No event source found for chain ${substrateChain}`)
+  }
   
   return eventSource
 }

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -6,11 +6,11 @@ let eventSource: GraphQLSource
 
 export * from './IProcessorSource'
 
-export async function getProcessorSource(): Promise<IProcessorSource> {
+export async function getProcessorSource(indexerEndpointURL: string): Promise<IProcessorSource> {
   if (!eventSource) {
     // just to make it async, do some async init here if needed
     await pImmediate()
-    eventSource = new GraphQLSource()
+    eventSource = new GraphQLSource(indexerEndpointURL)
   }
   return eventSource
 }

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -4,10 +4,10 @@ import pImmediate from 'p-immediate'
 
 export * from './IProcessorSource'
 
-export async function getProcessorSource(indexerEndpointURL: string): Promise<IProcessorSource> {
+export async function getProcessorSource(substrateChain: string, indexerEndpointURL: string): Promise<IProcessorSource> {
   // just to make it async, do some async init here if needed
   await pImmediate()
-  const eventSource = new GraphQLSource(indexerEndpointURL)
+  const eventSource = new GraphQLSource(substrateChain, indexerEndpointURL)
   
   return eventSource
 }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -12,17 +12,22 @@ const debug = Debug('hydra-processor:mappings-processor')
 
 export class MappingsProcessor {
   private _started = false
+  private indexerEndpointURL: string
   private eventQueue!: IBlockQueue
   private stateKeeper!: IStateKeeper
   private mappingsExecutor!: IMappingExecutor
+
+  constructor(indexerEndpointURL: string) {
+    this.indexerEndpointURL = indexerEndpointURL
+  }
 
   async start(): Promise<void> {
     info('Starting the processor')
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor()
-    this.eventQueue = await getBlockQueue()
-    this.stateKeeper = await getStateKeeper()
+    this.eventQueue = await getBlockQueue(this.indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(this.indexerEndpointURL)
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -74,7 +74,7 @@ export class MappingsProcessor {
 
         // now process the block with events
         if (next.done === true) {
-          info('All the blocks from the queue have been processed')
+          info(`All the blocks from the ${this.chainName} queue have been processed`)
           break
         }
 
@@ -82,17 +82,17 @@ export class MappingsProcessor {
 
         await this.processBlock(eventBlock)
       } catch (e: any) {
-        error(`Stopping the proccessor due to errors: ${logError(e)}`)
+        error(`Stopping the ${this.chainName} proccessor due to errors: ${logError(e)}`)
         this.stop()
         throw new Error(e)
       }
     }
-    info(`Terminating the processor`)
+    info(`Terminating the ${this.chainName} processor`)
   }
 
   private async processBlock(nextBlock: BlockData) {
     info(
-      `Processing block: ${nextBlock.block.id}, events count: ${nextBlock.events.length} `
+      `Processing ${this.chainName} block: ${nextBlock.block.id}, events count: ${nextBlock.events.length} `
     )
 
     await this.mappingsExecutor.executeBlock(
@@ -110,7 +110,7 @@ export class MappingsProcessor {
       eventEmitter.emit(ProcessorEvents.PROCESSED_EVENT, ctx.event)
     )
 
-    debug(`Done block ${nextBlock.block.height}`)
+    debug(`Done ${this.chainName} block ${nextBlock.block.height}`)
   }
 
   private shouldWork(): boolean {

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -13,11 +13,13 @@ const debug = Debug('hydra-processor:mappings-processor')
 export class MappingsProcessor {
   private _started = false
   private indexerEndpointURL: string
+  private substrateChain: string
   private eventQueue!: IBlockQueue
   private stateKeeper!: IStateKeeper
   private mappingsExecutor!: IMappingExecutor
 
-  constructor(indexerEndpointURL: string) {
+  constructor(substrateChain: string, indexerEndpointURL: string) {
+    this.substrateChain = substrateChain
     this.indexerEndpointURL = indexerEndpointURL
   }
 
@@ -26,8 +28,8 @@ export class MappingsProcessor {
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor()
-    this.eventQueue = await getBlockQueue(this.indexerEndpointURL)
-    this.stateKeeper = await getStateKeeper(this.indexerEndpointURL)
+    this.eventQueue = await getBlockQueue(this.substrateChain, this.indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(this.substrateChain, this.indexerEndpointURL)
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -12,12 +12,14 @@ const debug = Debug('hydra-processor:mappings-processor')
 
 export class MappingsProcessor {
   private _started = false
+  private chainName: string
   private indexerEndpointURL: string
   private eventQueue!: IBlockQueue
   private stateKeeper!: IStateKeeper
   private mappingsExecutor!: IMappingExecutor
 
-  constructor(indexerEndpointURL: string) {
+  constructor(chainName: string, indexerEndpointURL: string) {
+    this.chainName = chainName
     this.indexerEndpointURL = indexerEndpointURL
   }
 
@@ -26,8 +28,8 @@ export class MappingsProcessor {
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor()
-    this.eventQueue = await getBlockQueue(this.indexerEndpointURL)
-    this.stateKeeper = await getStateKeeper(this.indexerEndpointURL)
+    this.eventQueue = await getBlockQueue(this.chainName, this.indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(this.chainName, this.indexerEndpointURL)
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -7,8 +7,7 @@ import { error, info } from '../util/log'
 import { BlockData, getBlockQueue, IBlockQueue } from '../queue'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
 import { getMappingExecutor, IMappingExecutor, isTxAware } from '../executor'
-import { getManifest, getManifestMapping } from '../start/config'
-import { MappingsDef } from '../start/manifest'
+import { getManifestMapping } from '../start/config'
 const debug = Debug('hydra-processor:mappings-processor')
 
 export class MappingsProcessor {
@@ -25,7 +24,7 @@ export class MappingsProcessor {
   }
 
   async start(): Promise<void> {
-    info('Starting the processor')
+    info(`Starting the processor for ${this.chainName}`)
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor(this.chainName)

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -13,13 +13,11 @@ const debug = Debug('hydra-processor:mappings-processor')
 export class MappingsProcessor {
   private _started = false
   private indexerEndpointURL: string
-  private substrateChain: string
   private eventQueue!: IBlockQueue
   private stateKeeper!: IStateKeeper
   private mappingsExecutor!: IMappingExecutor
 
-  constructor(substrateChain: string, indexerEndpointURL: string) {
-    this.substrateChain = substrateChain
+  constructor(indexerEndpointURL: string) {
     this.indexerEndpointURL = indexerEndpointURL
   }
 
@@ -28,8 +26,8 @@ export class MappingsProcessor {
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor()
-    this.eventQueue = await getBlockQueue(this.substrateChain, this.indexerEndpointURL)
-    this.stateKeeper = await getStateKeeper(this.substrateChain, this.indexerEndpointURL)
+    this.eventQueue = await getBlockQueue(this.indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(this.indexerEndpointURL)
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -46,6 +46,7 @@ export function getMappingFilter(mappingsDef: MappingsDef): MappingFilter {
 export class BlockQueue implements IBlockQueue {
   _started = false
   _hasNext = true
+  substrateChain!: string
   indexerStatus!: IndexerStatus
   eventQueue: EventData[] = []
   stateKeeper!: IStateKeeper
@@ -58,6 +59,7 @@ export class BlockQueue implements IBlockQueue {
   async init(chainName: string, indexerEndpointURL: string): Promise<void> {
     info(`Waiting for the indexer head to be initialized`)
 
+    this.substrateChain = chainName
     this.stateKeeper = await getStateKeeper(chainName, indexerEndpointURL)
     this.dataSource = await getProcessorSource(indexerEndpointURL)
     for (const mapping of getManifest().mappings) {
@@ -129,7 +131,8 @@ export class BlockQueue implements IBlockQueue {
       this.indexerStatus = await this.dataSource.getIndexerStatus()
       eventEmitter.emit(
         ProcessorEvents.INDEXER_STATUS_CHANGE,
-        this.indexerStatus
+        this.indexerStatus,
+        this.substrateChain,
       )
       await delay(conf().POLL_INTERVAL_MS)
     }

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -55,11 +55,11 @@ export class BlockQueue implements IBlockQueue {
   indexerQueries!: { [key in Kind]?: Partial<IndexerQuery> }
   heightsWithHooks!: Range[]
 
-  async init(): Promise<void> {
+  async init(indexerEndpointURL: string): Promise<void> {
     info(`Waiting for the indexer head to be initialized`)
 
-    this.stateKeeper = await getStateKeeper()
-    this.dataSource = await getProcessorSource()
+    this.stateKeeper = await getStateKeeper(indexerEndpointURL)
+    this.dataSource = await getProcessorSource(indexerEndpointURL)
     this.mappingFilter = getMappingFilter(getManifest().mappings)
 
     await pWaitFor(async () => {

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -55,10 +55,10 @@ export class BlockQueue implements IBlockQueue {
   indexerQueries!: { [key in Kind]?: Partial<IndexerQuery> }
   heightsWithHooks!: Range[]
 
-  async init(indexerEndpointURL: string): Promise<void> {
+  async init(chainName: string, indexerEndpointURL: string): Promise<void> {
     info(`Waiting for the indexer head to be initialized`)
 
-    this.stateKeeper = await getStateKeeper(indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(chainName, indexerEndpointURL)
     this.dataSource = await getProcessorSource(indexerEndpointURL)
     this.mappingFilter = getMappingFilter(getManifest().mappings)
 

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -314,14 +314,14 @@ export class BlockQueue implements IBlockQueue {
       (query) => ({ ...this.rangeFilter, ...query } as IndexerQuery)
     )
 
-    debug(`Fetching next batch`)
+    debug(`Fetching next batch for ${this.substrateChain}`)
     const events = await this.dataSource.nextBatch(queries)
 
     // collect the events object into an array with types
     const trimmed = sortAndTrim(events)
     if (conf().VERBOSE) {
       debug(
-        `Enqueuing events: ${JSON.stringify(trimmed.map((e) => e.event.id))}`
+        `Enqueuing ${this.substrateChain} events: ${JSON.stringify(trimmed.map((e) => e.event.id))}`
       )
     }
 

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -214,7 +214,7 @@ export class BlockQueue implements IBlockQueue {
       )
 
       debug(
-        `Queue size: ${this.eventQueue.length}, max capacity: ${
+        `Queue size (${this.substrateChain}): ${this.eventQueue.length}, max capacity: ${
           conf().EVENT_QUEUE_MAX_CAPACITY
         }`
       )
@@ -329,7 +329,7 @@ export class BlockQueue implements IBlockQueue {
       trimmed.map((e) => parseEventId(e.event.id).blockHeight)
     )
 
-    if (conf().VERBOSE) debug(`Requesting blocks: ${blockHeights}`)
+    if (conf().VERBOSE) debug(`Requesting ${this.substrateChain} blocks: ${blockHeights}`)
 
     // prefetch to the cache
     await this.dataSource.fetchBlocks(blockHeights)

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -57,7 +57,7 @@ export class BlockQueue implements IBlockQueue {
   heightsWithHooks!: Range[]
 
   async init(chainName: string, indexerEndpointURL: string): Promise<void> {
-    info(`Waiting for the indexer head to be initialized`)
+    info(`Waiting for the ${chainName} indexer head to be initialized`)
 
     this.substrateChain = chainName
     this.stateKeeper = await getStateKeeper(chainName, indexerEndpointURL)
@@ -110,7 +110,7 @@ export class BlockQueue implements IBlockQueue {
   async start(): Promise<void> {
     this._started = true
 
-    info('Starting the event queue')
+    info(`Starting the ${this.substrateChain} event queue`)
 
     await Promise.all([this.pollIndexer(), this.fill()])
   }
@@ -160,12 +160,12 @@ export class BlockQueue implements IBlockQueue {
     // FIXME: this method only produces blocks with some event.
 
     while (this._started) {
-      debug(`Sealing new block`)
+      debug(`Sealing new ${this.substrateChain} block`)
 
       let nextEventData = await this.poll()
 
       if (nextEventData === undefined) {
-        debug(`The queue is empty and all the events were fetched`)
+        debug(`The ${this.substrateChain} queue is empty and all the events were fetched`)
         return
       }
 
@@ -175,7 +175,7 @@ export class BlockQueue implements IBlockQueue {
         nextEventData.event.blockNumber
       )
 
-      debug(`Next block: ${block.id}`)
+      debug(`Next ${this.substrateChain} block: ${block.id}`)
       // wait until all the events up to blockNumber are fully fetched
       pWaitFor(() => this.rangeFilter.block.gt >= block.height)
 
@@ -189,9 +189,9 @@ export class BlockQueue implements IBlockQueue {
       }
 
       // the event is from a new block, yield the current
-      debug(`Yielding block ${block.id}`)
+      debug(`Yielding ${this.substrateChain} block ${block.id}`)
       if (conf().VERBOSE)
-        debug(`Block contents: ${JSON.stringify(block, null, 2)}`)
+        debug(`Block contents (${this.substrateChain}): ${JSON.stringify(block, null, 2)}`)
 
       yield {
         block,
@@ -223,7 +223,7 @@ export class BlockQueue implements IBlockQueue {
 
       this.eventQueue.push(...events)
 
-      debug(`Pushed ${events.length} events to the queue`)
+      debug(`Pushed ${events.length} events to the ${this.substrateChain} queue`)
 
       if (events.length > 0) {
         this.rangeFilter.id.gt = last(events)?.event.id as string
@@ -248,6 +248,7 @@ export class BlockQueue implements IBlockQueue {
 
       debug(
         `Event queue state:
+          \tSubstrate cahin: ${this.substrateChain}
           \tIndexer head: ${this.indexerStatus.head}
           \tChain head: ${this.indexerStatus.chainHeight} 
           \tQueue size: ${this.eventQueue.length}

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -248,7 +248,7 @@ export class BlockQueue implements IBlockQueue {
 
       debug(
         `Event queue state:
-          \tSubstrate cahin: ${this.substrateChain}
+          \tSubstrate chain: ${this.substrateChain}
           \tIndexer head: ${this.indexerStatus.head}
           \tChain head: ${this.indexerStatus.chainHeight} 
           \tQueue size: ${this.eventQueue.length}

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -61,7 +61,7 @@ export class BlockQueue implements IBlockQueue {
 
     this.substrateChain = chainName
     this.stateKeeper = await getStateKeeper(chainName, indexerEndpointURL)
-    this.dataSource = await getProcessorSource(indexerEndpointURL)
+    this.dataSource = await getProcessorSource(chainName, indexerEndpointURL)
     for (const mapping of getManifest().mappings) {
       if (mapping.substrateChain === chainName) {
         this.mappingFilter = getMappingFilter(mapping)
@@ -127,7 +127,7 @@ export class BlockQueue implements IBlockQueue {
     // });
     // For now, simply update indexerHead regularly
     while (this._started && this._hasNext) {
-      debug("retrieving indexer status")
+      debug(`retrieving ${this.substrateChain} indexer status`)
       this.indexerStatus = await this.dataSource.getIndexerStatus()
       eventEmitter.emit(
         ProcessorEvents.INDEXER_STATUS_CHANGE,

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -111,6 +111,7 @@ export class BlockQueue implements IBlockQueue {
     // });
     // For now, simply update indexerHead regularly
     while (this._started && this._hasNext) {
+      debug("retrieving indexer status")
       this.indexerStatus = await this.dataSource.getIndexerStatus()
       eventEmitter.emit(
         ProcessorEvents.INDEXER_STATUS_CHANGE,

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -49,19 +49,16 @@ export class BlockQueue implements IBlockQueue {
   indexerStatus!: IndexerStatus
   eventQueue: EventData[] = []
   stateKeeper!: IStateKeeper
-  substrateChain!: string
   dataSource!: IProcessorSource
   mappingFilter!: MappingFilter
   rangeFilter!: RangeFilter
   indexerQueries!: { [key in Kind]?: Partial<IndexerQuery> }
   heightsWithHooks!: Range[]
 
-  async init(substrateChain: string, indexerEndpointURL: string): Promise<void> {
+  async init(indexerEndpointURL: string): Promise<void> {
     info(`Waiting for the indexer head to be initialized`)
 
-    this.substrateChain = substrateChain
-
-    this.stateKeeper = await getStateKeeper(substrateChain, indexerEndpointURL)
+    this.stateKeeper = await getStateKeeper(indexerEndpointURL)
     this.dataSource = await getProcessorSource(indexerEndpointURL)
     this.mappingFilter = getMappingFilter(getManifest().mappings)
 
@@ -117,8 +114,7 @@ export class BlockQueue implements IBlockQueue {
       this.indexerStatus = await this.dataSource.getIndexerStatus()
       eventEmitter.emit(
         ProcessorEvents.INDEXER_STATUS_CHANGE,
-        this.indexerStatus,
-        this.substrateChain,
+        this.indexerStatus
       )
       await delay(conf().POLL_INTERVAL_MS)
     }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -3,9 +3,19 @@ import { IBlockQueue } from './IBlockQueue'
 
 export * from './IBlockQueue'
 
+let blockQueues: Map<string, IBlockQueue> = new Map()
+
 export async function getBlockQueue(chainName: string, indexerEndpointURL: string): Promise<IBlockQueue> {
-  const blockQueue = new BlockQueue()
-  await blockQueue.init(chainName, indexerEndpointURL)
+  if (!blockQueues.has(chainName)) {
+    const blockQueue = new BlockQueue()
+    await blockQueue.init(chainName, indexerEndpointURL)
+    blockQueues.set(chainName, blockQueue)
+  }
   
+  const blockQueue = blockQueues.get(chainName)
+  if (!blockQueue) {
+    throw new Error(`BlockQueue not found for chain ${chainName}`)
+  }
+
   return blockQueue
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -3,9 +3,9 @@ import { IBlockQueue } from './IBlockQueue'
 
 export * from './IBlockQueue'
 
-export async function getBlockQueue(substrateChain: string, indexerEndpointURL: string): Promise<IBlockQueue> {
+export async function getBlockQueue(indexerEndpointURL: string): Promise<IBlockQueue> {
   const blockQueue = new BlockQueue()
-  await blockQueue.init(substrateChain, indexerEndpointURL)
+  await blockQueue.init(indexerEndpointURL)
   
   return blockQueue
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -3,9 +3,9 @@ import { IBlockQueue } from './IBlockQueue'
 
 export * from './IBlockQueue'
 
-export async function getBlockQueue(indexerEndpointURL: string): Promise<IBlockQueue> {
+export async function getBlockQueue(chainName: string, indexerEndpointURL: string): Promise<IBlockQueue> {
   const blockQueue = new BlockQueue()
-  await blockQueue.init(indexerEndpointURL)
+  await blockQueue.init(chainName, indexerEndpointURL)
   
   return blockQueue
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -3,9 +3,9 @@ import { IBlockQueue } from './IBlockQueue'
 
 export * from './IBlockQueue'
 
-export async function getBlockQueue(indexerEndpointURL: string): Promise<IBlockQueue> {
+export async function getBlockQueue(substrateChain: string, indexerEndpointURL: string): Promise<IBlockQueue> {
   const blockQueue = new BlockQueue()
-  await blockQueue.init(indexerEndpointURL)
+  await blockQueue.init(substrateChain, indexerEndpointURL)
   
   return blockQueue
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -5,10 +5,10 @@ export * from './IBlockQueue'
 
 let blockQueue: BlockQueue
 
-export async function getBlockQueue(): Promise<IBlockQueue> {
+export async function getBlockQueue(indexerEndpointURL: string): Promise<IBlockQueue> {
   if (!blockQueue) {
     blockQueue = new BlockQueue()
-    await blockQueue.init()
+    await blockQueue.init(indexerEndpointURL)
   }
   return blockQueue
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -3,12 +3,9 @@ import { IBlockQueue } from './IBlockQueue'
 
 export * from './IBlockQueue'
 
-let blockQueue: BlockQueue
-
 export async function getBlockQueue(indexerEndpointURL: string): Promise<IBlockQueue> {
-  if (!blockQueue) {
-    blockQueue = new BlockQueue()
-    await blockQueue.init(indexerEndpointURL)
-  }
+  const blockQueue = new BlockQueue()
+  await blockQueue.init(indexerEndpointURL)
+  
   return blockQueue
 }

--- a/packages/hydra-processor/src/start/ProcessorRunner.ts
+++ b/packages/hydra-processor/src/start/ProcessorRunner.ts
@@ -49,6 +49,9 @@ export class ProcessorRunner {
       this.processors?.push(new MappingsProcessor(chain.indexerEndpointURL))
     }
 
+    info(`Created ${this.processors.length} processors`)
+    info(JSON.stringify(this.processors))
+
     try {
       const promClient = new ProcessorPromClient()
       promClient.init()

--- a/packages/hydra-processor/src/start/ProcessorRunner.ts
+++ b/packages/hydra-processor/src/start/ProcessorRunner.ts
@@ -46,7 +46,7 @@ export class ProcessorRunner {
 
     this.processors = []
     for (const chain of getManifest().processor.chains) {
-      this.processors?.push(new MappingsProcessor(chain.name, chain.indexerEndpointURL))
+      this.processors?.push(new MappingsProcessor(chain.indexerEndpointURL))
     }
 
     info(`Created ${this.processors.length} processors`)

--- a/packages/hydra-processor/src/start/ProcessorRunner.ts
+++ b/packages/hydra-processor/src/start/ProcessorRunner.ts
@@ -46,7 +46,7 @@ export class ProcessorRunner {
 
     this.processors = []
     for (const chain of getManifest().processor.chains) {
-      this.processors?.push(new MappingsProcessor(chain.indexerEndpointURL))
+      this.processors?.push(new MappingsProcessor(chain.name, chain.indexerEndpointURL))
     }
 
     info(`Created ${this.processors.length} processors`)

--- a/packages/hydra-processor/src/start/config.ts
+++ b/packages/hydra-processor/src/start/config.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { cleanEnv, str, num, bool } from 'envalid'
-import { parseManifest, ProcessorManifest } from './manifest'
+import { parseManifest, ProcessorManifest, MappingsDef } from './manifest'
 import Debug from 'debug'
 import { setWarthogEnvs } from '../db/ormconfig'
 
@@ -89,4 +89,9 @@ export function getManifest(): ProcessorManifest {
     manifest = parseManifest(getConfig().MANIFEST_PATH)
   }
   return manifest
+}
+
+export function getManifestMapping(substrateChain: string): MappingsDef | undefined {
+  const manifest = getManifest()
+  return manifest.mappings.find((m) => m.substrateChain === substrateChain)
 }

--- a/packages/hydra-processor/src/start/config.ts
+++ b/packages/hydra-processor/src/start/config.ts
@@ -7,8 +7,6 @@ import { setWarthogEnvs } from '../db/ormconfig'
 let conf: {
   // manifest file location
   MANIFEST_PATH: string
-  // url of the indexer to connect to
-  INDEXER_ENDPOINT_URL: string
   NAME: string
   ID: string
   // debug pattern
@@ -52,7 +50,6 @@ let conf: {
 export function configure(): void {
   const envConf = cleanEnv(process.env, {
     MANIFEST_PATH: str({ default: 'manifest.yml' }),
-    INDEXER_ENDPOINT_URL: str({ devDefault: 'http://localhost:4001' }),
     NAME: str({ default: 'Hydra-Processor' }),
     ID: str({ default: 'hydra-processor' }),
     DEBUG: str({ default: 'hydra-processor:*' }),

--- a/packages/hydra-processor/src/start/manifest.ts
+++ b/packages/hydra-processor/src/start/manifest.ts
@@ -23,6 +23,14 @@ const manifestValidatorOptions = {
     'repository?': 'string',
     hydraVersion: 'string',
     'indexerVersionRange?': 'string?',
+    processor: {
+      chains: [
+        {
+          name: 'string',
+          indexerEndpointURL: 'string',
+        },
+      ],
+    },
     mappings: {
       mappingsModule: 'string',
       'imports?': ['string'],
@@ -137,12 +145,22 @@ export function hasEvent(handler: unknown): handler is { event: string } {
   return (handler as any).event !== undefined
 }
 
+export interface Processor {
+  chains: ProcessorChain[]
+}
+
+export interface ProcessorChain {
+  name: string
+  indexerEndpointURL: string
+}
+
 export interface ProcessorManifest {
   version: string
   hydraVersion: string
   indexerVersionRange: string
   description?: string
   repository?: string
+  processor: Processor
   mappings: MappingsDef
 }
 
@@ -163,6 +181,7 @@ export function parseManifest(manifestLoc: string): ProcessorManifest {
     indexerVersionRange?: string
     description?: string
     repository?: string
+    processor: Processor
     mappings: MappingsDefInput
   }
 

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -26,7 +26,10 @@ export class StateKeeper implements IStateKeeper {
     // }
     eventEmitter.on(
       ProcessorEvents.INDEXER_STATUS_CHANGE,
-      (indexerStatus) => (this.indexerStatus = indexerStatus)
+      (indexerStatus) => {
+        debug("recieved indexer status: "+JSON.stringify(indexerStatus))
+        this.indexerStatus = indexerStatus
+      }
     )
 
     const throttle = pThrottle({

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -94,10 +94,10 @@ export class StateKeeper implements IStateKeeper {
     eventEmitter.emit(ProcessorEvents.STATE_CHANGE, this.processorState)
   }
 
-  async init(): Promise<IProcessorState> {
+  async init(indexerEndpointURL: string): Promise<IProcessorState> {
     const lastState = await loadState(conf().ID)
 
-    const processorSource = await getProcessorSource()
+    const processorSource = await getProcessorSource(indexerEndpointURL)
 
     this.indexerStatus = await processorSource.getIndexerStatus()
 

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -35,13 +35,7 @@ export class StateKeeper implements IStateKeeper {
     })
 
     const stateLog = throttle(() => {
-      const syncStatus =
-        this.indexerStatus.chainHeight > 0
-          ? `${
-              this.indexerStatus.chainHeight -
-              this.processorState.lastScannedBlock
-            } blocks behind`
-          : `Connecting to the indexer...`
+      const syncStatus = this.indexerStatus ? this.indexerStatus.chainHeight > 0 ? `${this.indexerStatus.chainHeight - this.processorState.lastScannedBlock} blocks behind`: `Connecting to the indexer...` : 'Waiting for indexer status...'
       info(
         `Last block: ${this.processorState.lastScannedBlock} \t: ${syncStatus}`
       )

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -38,7 +38,11 @@ export class StateKeeper implements IStateKeeper {
     })
 
     const stateLog = throttle(() => {
-      const syncStatus = this.indexerStatus ? this.indexerStatus.chainHeight > 0 ? `${this.indexerStatus.chainHeight - this.processorState.lastScannedBlock} blocks behind`: `Connecting to the indexer...` : 'Waiting for indexer status...'
+      if (!this.indexerStatus || !this.processorState) {
+        return
+      }
+      
+      const syncStatus = this.indexerStatus.chainHeight > 0 ? `${this.indexerStatus.chainHeight - this.processorState.lastScannedBlock} blocks behind`: `Connecting to the indexer...`
       info(
         `Last block: ${this.processorState.lastScannedBlock} \t: ${syncStatus}`
       )

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -28,9 +28,11 @@ export class StateKeeper implements IStateKeeper {
     this.chainName = chainName
     eventEmitter.on(
       ProcessorEvents.INDEXER_STATUS_CHANGE,
-      (indexerStatus) => {
-        debug("recieved indexer status: "+JSON.stringify({name: this.chainName, status: indexerStatus}))
-        this.indexerStatus = indexerStatus
+      (indexerStatus, chainName) => {
+        if (chainName === this.chainName) {
+          debug("recieved indexer status: "+JSON.stringify({name: this.chainName, status: indexerStatus}))
+          this.indexerStatus = indexerStatus
+        }
       }
     )
 

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -18,22 +18,15 @@ export class StateKeeper implements IStateKeeper {
   private processorState!: IProcessorState
   private indexerStatus!: IndexerStatus
   private processorSource!: IProcessorSource
-  private substrateChain: string 
 
-  constructor(substrateChain: string) {
+  constructor() {
     // this.indexerStatus = {
     //   head: -1,
     //   chainHeight: -1,
     // }
-    this.substrateChain = substrateChain
-
     eventEmitter.on(
       ProcessorEvents.INDEXER_STATUS_CHANGE,
-      (indexerStatus, substrateChain) => {
-        if (substrateChain === this.substrateChain) {
-          this.indexerStatus = indexerStatus
-        }
-      }
+      (indexerStatus) => (this.indexerStatus = indexerStatus)
     )
 
     const throttle = pThrottle({

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -7,7 +7,7 @@ import { getProcessorSource, IProcessorSource } from '../ingest'
 import Debug from 'debug'
 import pThrottle from 'p-throttle'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
-import { getConfig as conf, getManifest } from '../start/config'
+import { getConfig as conf, getManifest, getManifestMapping } from '../start/config'
 import { isInRange, Range, parseEventId, info, warn } from '../util'
 import { formatEventId, SubstrateEvent } from '@subsquid/hydra-common'
 import { IndexerStatus } from '.'
@@ -111,9 +111,13 @@ export class StateKeeper implements IStateKeeper {
       getManifest().indexerVersionRange
     )
 
-    const range = getManifest().mappings.range
+    const mapping = getManifestMapping(this.chainName)
+    
+    if (!mapping) {
+      throw new Error(`No mapping found for chain ${this.chainName}`)
+    }
 
-    this.processorState = initState(range, lastState)
+    this.processorState = initState(mapping.range, lastState)
     eventEmitter.emit(ProcessorEvents.STATE_CHANGE, this.processorState)
 
     return this.processorState

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -18,15 +18,22 @@ export class StateKeeper implements IStateKeeper {
   private processorState!: IProcessorState
   private indexerStatus!: IndexerStatus
   private processorSource!: IProcessorSource
+  private substrateChain: string 
 
-  constructor() {
+  constructor(substrateChain: string) {
     // this.indexerStatus = {
     //   head: -1,
     //   chainHeight: -1,
     // }
+    this.substrateChain = substrateChain
+
     eventEmitter.on(
       ProcessorEvents.INDEXER_STATUS_CHANGE,
-      (indexerStatus) => (this.indexerStatus = indexerStatus)
+      (indexerStatus, substrateChain) => {
+        if (substrateChain === this.substrateChain) {
+          this.indexerStatus = indexerStatus
+        }
+      }
     )
 
     const throttle = pThrottle({

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -86,6 +86,7 @@ export class StateKeeper implements IStateKeeper {
 
     const processed = new ProcessedEventsLogEntity()
     processed.processor = conf().ID
+    processed.substrateChain = this.chainName
     processed.eventId = this.processorState.lastProcessedEvent
     processed.lastScannedBlock = this.processorState.lastScannedBlock
     processed.chainHead = this.indexerStatus.chainHeight

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -100,7 +100,7 @@ export class StateKeeper implements IStateKeeper {
   }
 
   async init(indexerEndpointURL: string): Promise<IProcessorState> {
-    const lastState = await loadState(conf().ID)
+    const lastState = await loadState(conf().ID, this.chainName)
 
     const processorSource = await getProcessorSource(this.chainName, indexerEndpointURL)
 

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -102,7 +102,7 @@ export class StateKeeper implements IStateKeeper {
   async init(indexerEndpointURL: string): Promise<IProcessorState> {
     const lastState = await loadState(conf().ID)
 
-    const processorSource = await getProcessorSource(indexerEndpointURL)
+    const processorSource = await getProcessorSource(this.chainName, indexerEndpointURL)
 
     this.indexerStatus = await processorSource.getIndexerStatus()
 

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -15,19 +15,21 @@ import { validateIndexerVersion } from './version'
 const debug = Debug('hydra-processor:processor-state-handler')
 
 export class StateKeeper implements IStateKeeper {
+  private chainName: string
   private processorState!: IProcessorState
   private indexerStatus!: IndexerStatus
   private processorSource!: IProcessorSource
 
-  constructor() {
+  constructor(chainName: string) {
     // this.indexerStatus = {
     //   head: -1,
     //   chainHeight: -1,
     // }
+    this.chainName = chainName
     eventEmitter.on(
       ProcessorEvents.INDEXER_STATUS_CHANGE,
       (indexerStatus) => {
-        debug("recieved indexer status: "+JSON.stringify(indexerStatus))
+        debug("recieved indexer status: "+JSON.stringify({name: this.chainName, status: indexerStatus}))
         this.indexerStatus = indexerStatus
       }
     )
@@ -41,7 +43,7 @@ export class StateKeeper implements IStateKeeper {
       if (!this.indexerStatus || !this.processorState) {
         return
       }
-      
+
       const syncStatus = this.indexerStatus.chainHeight > 0 ? `${this.indexerStatus.chainHeight - this.processorState.lastScannedBlock} blocks behind`: `Connecting to the indexer...`
       info(
         `Last block: ${this.processorState.lastScannedBlock} \t: ${syncStatus}`

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -48,7 +48,7 @@ export class StateKeeper implements IStateKeeper {
 
       const syncStatus = this.indexerStatus.chainHeight > 0 ? `${this.indexerStatus.chainHeight - this.processorState.lastScannedBlock} blocks behind`: `Connecting to the indexer...`
       info(
-        `Last block: ${this.processorState.lastScannedBlock} \t: ${syncStatus}`
+        `Last ${this.chainName} block: ${this.processorState.lastScannedBlock} \t: ${syncStatus}`
       )
     })
 

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -4,12 +4,9 @@ import { StateKeeper } from './StateKeeper'
 export * from './IStateKeeper'
 export * from './StateKeeper'
 
-let stateKeeper: StateKeeper
-
 export async function getStateKeeper(indexerEndpointURL: string): Promise<IStateKeeper> {
-  if (!stateKeeper) {
-    stateKeeper = new StateKeeper()
-    await stateKeeper.init(indexerEndpointURL)
-  }
+  const stateKeeper = new StateKeeper()
+  await stateKeeper.init(indexerEndpointURL)
+  
   return stateKeeper
 }

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -4,8 +4,8 @@ import { StateKeeper } from './StateKeeper'
 export * from './IStateKeeper'
 export * from './StateKeeper'
 
-export async function getStateKeeper(substrateChain: string, indexerEndpointURL: string): Promise<IStateKeeper> {
-  const stateKeeper = new StateKeeper(substrateChain)
+export async function getStateKeeper(indexerEndpointURL: string): Promise<IStateKeeper> {
+  const stateKeeper = new StateKeeper()
   await stateKeeper.init(indexerEndpointURL)
   
   return stateKeeper

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -16,7 +16,7 @@ export async function getStateKeeper(chainName: string, indexerEndpointURL: stri
   
   const stateKeeper = stateKeepers.get(chainName)
   if (!stateKeeper) {
-    throw new Error(`State keeper for chain ${chainName} not found`)
+    throw new Error(`StateKeeper for chain ${chainName} not found`)
   }
 
   return stateKeeper

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -4,9 +4,20 @@ import { StateKeeper } from './StateKeeper'
 export * from './IStateKeeper'
 export * from './StateKeeper'
 
+let stateKeepers: Map<string, IStateKeeper> = new Map()
+
 export async function getStateKeeper(chainName: string, indexerEndpointURL: string): Promise<IStateKeeper> {
-  const stateKeeper = new StateKeeper(chainName)
-  await stateKeeper.init(indexerEndpointURL)
+  if (!stateKeepers.has(chainName)) {
+    const stateKeeper = new StateKeeper(chainName)
+    await stateKeeper.init(indexerEndpointURL)
+
+    stateKeepers.set(chainName, stateKeeper)
+  }
   
+  const stateKeeper = stateKeepers.get(chainName)
+  if (!stateKeeper) {
+    throw new Error(`State keeper for chain ${chainName} not found`)
+  }
+
   return stateKeeper
 }

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -6,10 +6,10 @@ export * from './StateKeeper'
 
 let stateKeeper: StateKeeper
 
-export async function getStateKeeper(): Promise<IStateKeeper> {
+export async function getStateKeeper(indexerEndpointURL: string): Promise<IStateKeeper> {
   if (!stateKeeper) {
     stateKeeper = new StateKeeper()
-    await stateKeeper.init()
+    await stateKeeper.init(indexerEndpointURL)
   }
   return stateKeeper
 }

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -4,8 +4,8 @@ import { StateKeeper } from './StateKeeper'
 export * from './IStateKeeper'
 export * from './StateKeeper'
 
-export async function getStateKeeper(indexerEndpointURL: string): Promise<IStateKeeper> {
-  const stateKeeper = new StateKeeper()
+export async function getStateKeeper(substrateChain: string, indexerEndpointURL: string): Promise<IStateKeeper> {
+  const stateKeeper = new StateKeeper(substrateChain)
   await stateKeeper.init(indexerEndpointURL)
   
   return stateKeeper

--- a/packages/hydra-processor/src/state/index.ts
+++ b/packages/hydra-processor/src/state/index.ts
@@ -4,8 +4,8 @@ import { StateKeeper } from './StateKeeper'
 export * from './IStateKeeper'
 export * from './StateKeeper'
 
-export async function getStateKeeper(indexerEndpointURL: string): Promise<IStateKeeper> {
-  const stateKeeper = new StateKeeper()
+export async function getStateKeeper(chainName: string, indexerEndpointURL: string): Promise<IStateKeeper> {
+  const stateKeeper = new StateKeeper(chainName)
   await stateKeeper.init(indexerEndpointURL)
   
   return stateKeeper

--- a/packages/hydra-processor/src/state/version.ts
+++ b/packages/hydra-processor/src/state/version.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 const debug = Debug('hydra-processor:util')
 
-export const PROCESSOR_PACKAGE_NAME = '@subsquid/hydra-processor'
+export const PROCESSOR_PACKAGE_NAME = '@cpurta/hydra-processor'
 
 export function validateHydraVersion(hydraVersion: string): void {
   const oursHydraVersion = getHydraVersion()


### PR DESCRIPTION
This allows for multiple chains to be processed in parallel. It includes support for a new processor configuration which allows for a processor for each chain provided and an update to the mappings to support an array of mapping configurations.

Sample manifest:
```yaml
version: '3.0'
description: Test manifest
repository: https://github.com/
hydraVersion: "4"

typegen:
  metadata:
    source: wss://kusama-rpc.polkadot.io/
    blockHash: '0x98af7de0c69107bcdd5033d84cfee0e331514dc42e0a45b9d64e82b0dcec13a2'
  events:
    - balances.Transfer
  calls:
    - timestamp.set
  outDir: chain/kusama

processor:
  chains:
    - name: polkadot
      indexerEndpointURL: https://polkadot.indexer.gc.subsquid.io/v4/graphql
    - name: kusama
      indexerEndpointURL: https://kusama.indexer.gc.subsquid.io/v4/graphql

mappings:
  - substrateChain: polkadot
    mappingsModule: mappings/polkadot
    eventHandlers:
      - event: balances.Transfer
        handler: balancesTransfer
    extrinsicHandlers:
    preBlockHooks:
    postBlockHooks:
  - substrateChain: kusama
    mappingsModule: mappings/kusama
    eventHandlers:
      - event: balances.Transfer
        handler: balancesTransfer
    extrinsicHandlers:
    preBlockHooks:
    postBlockHooks:
```

The processors will pull each block from the respective indexer provided in the configuration and send that to a mappings processor which applies the appropriate mapping to the block and inserts it into postgres. 