### PR TITLE
feat: Allow indexer database connections to use SSL for extra security

### DIFF
--- a/packages/hydra-indexer/src/db/dbconfig.ts
+++ b/packages/hydra-indexer/src/db/dbconfig.ts
@@ -17,6 +17,10 @@ const config: (name?: string) => ConnectionOptions = (name) => {
     username: conf.DB_USER,
     password: conf.DB_PASS,
     database: conf.DB_NAME,
+    ssl: conf.DB_SSL_ENABLED ? {
+      rejectUnauthorized: false,
+      cert: conf.DB_SSL_CERT,
+    } : {},
     entities: [
       SubstrateEventEntity,
       SubstrateExtrinsicEntity,


### PR DESCRIPTION
This should allow for the hydra indexer to use SSL connections to the Postgres database if needed. I found that this is needed for certain hosted databases (DigitalOcean) that require SSL connections by default and you are not allowed to modify the SSL connection requirement.