### PR TITLE
fix: duplication of extrinsics when events are requested

### DIFF
--- a/packages/hydra-e2e-tests/docker-compose.yml
+++ b/packages/hydra-e2e-tests/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - hydra-indexer-status-service
       - hydra-indexer
     environment:
-#      DEV_MODE: "true"
+      DEV_MODE: "true"
       DB_NAME: indexer-db
       DB_USER: postgres
       DB_PASS: postgres

--- a/packages/hydra-indexer-gateway/metadata/databases/HydraIndexer/tables/public_substrate_extrinsic.yaml
+++ b/packages/hydra-indexer-gateway/metadata/databases/HydraIndexer/tables/public_substrate_extrinsic.yaml
@@ -10,16 +10,14 @@ configuration:
     is_signed: isSigned
     version_info: versionInfo
   custom_root_fields: {}
-object_relationships:
-- name: event
+array_relationships:
+  name: substrate_events
   using:
-    manual_configuration:
-      column_mapping:
-        id: extrinsic_id
-      insertion_order: null
-      remote_table:
-        name: substrate_event
+    foreign_key_constraint_on:
+      column: extrinsic_id
+      table:
         schema: public
+        name: substrate_event
 select_permissions:
 - permission:
     allow_aggregations: true

--- a/packages/hydra-indexer-gateway/metadata/databases/HydraIndexer/tables/public_substrate_extrinsic.yaml
+++ b/packages/hydra-indexer-gateway/metadata/databases/HydraIndexer/tables/public_substrate_extrinsic.yaml
@@ -11,13 +11,13 @@ configuration:
     version_info: versionInfo
   custom_root_fields: {}
 array_relationships:
-  name: substrate_events
-  using:
-    foreign_key_constraint_on:
-      column: extrinsic_id
-      table:
-        schema: public
-        name: substrate_event
+  - name: substrate_events
+    using:
+      foreign_key_constraint_on:
+        column: extrinsic_id
+        table:
+          schema: public
+          name: substrate_event
 select_permissions:
 - permission:
     allow_aggregations: true


### PR DESCRIPTION
affects: @subsquid/hydra-indexer-gateway

The query like

```graphql
query {
  substrate_extrinsic(where:{blockNumber:{_eq:8945349}}){
    section
    signer
    method
    id
    args
    hash
    indexInBlock
    tip
    signature
    hash
    event {
      name
      id
    }
  }
}
```

no longer produces duplicates. 

Also `event` was renamed to `substrate_events`.