### PR TITLE
feat: hydra-processor metrics extension

### DIFF
--- a/packages/hydra-processor/src/prometheus/ProcessorPromClient.ts
+++ b/packages/hydra-processor/src/prometheus/ProcessorPromClient.ts
@@ -4,7 +4,7 @@ import { SubstrateEvent, logError } from '@subsquid/hydra-common'
 import Debug from 'debug'
 import { countProcessedEvents } from '../db'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
-import { getConfig as conf } from '../start/config'
+import { getConfig as conf, getManifest } from '../start/config'
 
 const debug = Debug('index-builder:processor-prom-client')
 
@@ -33,6 +33,16 @@ export class ProcessorPromClient {
   protected eventQueueSize = new Gauge({
     name: 'hydra_processor_event_queue_size',
     help: 'Number of events in the queue',
+  })
+
+  protected rangeFrom = new Gauge({
+    name: 'hydra_processor_range_from',
+    help: 'Range.from',
+  })
+
+  protected rangeTo = new Gauge({
+    name: 'hydra_processor_range_to',
+    help: 'Range.to',
   })
 
   init(): void {
@@ -73,5 +83,7 @@ export class ProcessorPromClient {
   private async initValues(): Promise<void> {
     const totalEvents = await countProcessedEvents(conf().ID)
     this.processedEvents.set(totalEvents)
+    this.rangeFrom.set(getManifest().mappings.range.from)
+    this.rangeTo.set(getManifest().mappings.range.to)
   }
 }

--- a/packages/hydra-processor/src/prometheus/server.ts
+++ b/packages/hydra-processor/src/prometheus/server.ts
@@ -11,8 +11,12 @@ export function startPromEndpoint(): Server {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server.get('/metrics', (req: any, res: any) => {
     try {
-      res.set('Content-Type', register.contentType)
-      res.end(register.metrics())
+      if (req.query.json === 'true') {
+        res.json(register.getMetricsAsJSON())
+      } else {
+        res.set('Content-Type', register.contentType)
+        res.end(register.metrics())
+      }
     } catch (ex) {
       res.status(500).end(ex)
     }


### PR DESCRIPTION
affects: @subsquid/hydra-processor

hydra-processor metrics extension

Important changes for fetching processor sync status from API!